### PR TITLE
fix match method crop image failed

### DIFF
--- a/atx/drivers/mixin.py
+++ b/atx/drivers/mixin.py
@@ -283,7 +283,7 @@ class DeviceMixin(object):
         # image match
         screen = imutils.from_pillow(screen) # convert to opencv image
         if rect and isinstance(rect, tuple) and len(rect) == 4:
-            (x0, y0, x1, y1) = [v*pattern_scale for v in rect]
+            (x0, y0, x1, y1) = [int(v*pattern_scale) for v in rect]
             (dx, dy) = dx+x0, dy+y0
             screen = imutils.crop(screen, x0, y0, x1, y1)
             #cv2.imwrite('cc.png', screen)


### PR DESCRIPTION

### 说明：
numpy切片传入的必须是整型，而v*pattern_scale

 会生成 浮点型，导致imutils.crop中的 image[top:bottom, left:right] 切片失败，

### 场景：
`
home_rect = (int(screenw * 0.875), int(screenh * 0.5), screenw, screenh)
d.click_image("home@auto.png", rect=home_rect)
`